### PR TITLE
SAM-26: Add terraform to deploy FE

### DIFF
--- a/.github/workflows/terraform_master_workflow.yml
+++ b/.github/workflows/terraform_master_workflow.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - 'main'
+  workflow_dispatch:
+
 env:
   SANDBOX_IAM_ROLE: arn:aws:iam::242906888793:role/AWS_Sandbox
 jobs:

--- a/.github/workflows/terraform_plan.yml
+++ b/.github/workflows/terraform_plan.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Terraform
         uses: ./composite_actions/setup_tf
         with:
-          terraform-version: '1.4.0'
+          terraform-version: '1.5.1'
 
       - name: Verify Terraform version
         run: terraform --version

--- a/.github/workflows/terraform_pull_request_workflow.yml
+++ b/.github/workflows/terraform_pull_request_workflow.yml
@@ -1,6 +1,6 @@
 name: Terraform plan on PR
 run-name: Terraform plan on PR
-on: [pull_request]
+on: [pull_request, workflow_dispatch]
 jobs:
   terraform-plan:
     uses: ./.github/workflows/terraform_plan.yml

--- a/.github/workflows/terraform_pull_request_workflow.yml
+++ b/.github/workflows/terraform_pull_request_workflow.yml
@@ -1,6 +1,6 @@
 name: Terraform plan on PR
 run-name: Terraform plan on PR
-on: [pull_request, workflow_dispatch]
+on: [pull_request]
 jobs:
   terraform-plan:
     uses: ./.github/workflows/terraform_plan.yml

--- a/composite_actions/setup_tf/action.yml
+++ b/composite_actions/setup_tf/action.yml
@@ -4,7 +4,7 @@ inputs:
   terraform-version:
     description: 'Terraform version'
     required: false
-    default: '1.4.0'
+    default: '1.5.1'
 runs:
   using: "composite"
   steps:

--- a/infra/bootstrap-main.tf
+++ b/infra/bootstrap-main.tf
@@ -1,6 +1,5 @@
 # Call the seed_module to build our ADO seed info
-#module "bootstrap" {
-#  source                       = "./modules/bootstrap"
-#  s3_bucket_tf_state_name      = "sam2n-tf-state-bucket"
-#  dynamo_db_tf_lock_table_name = "sam2n-terraform-locks"
-#}
+module "bootstrap" {
+  source                       = "./modules/bootstrap"
+  dynamo_db_tf_lock_table_name = "sam2n-terraform-locks"
+}

--- a/infra/bootstrap-main.tf
+++ b/infra/bootstrap-main.tf
@@ -1,6 +1,6 @@
 # Call the seed_module to build our ADO seed info
-module "bootstrap" {
-  source                       = "./modules/bootstrap"
-  s3_bucket_tf_state_name      = "sam2n-tf-state-bucket"
-  dynamo_db_tf_lock_table_name = "sam2n-terraform-locks"
-}
+#module "bootstrap" {
+#  source                       = "./modules/bootstrap"
+#  s3_bucket_tf_state_name      = "sam2n-tf-state-bucket"
+#  dynamo_db_tf_lock_table_name = "sam2n-terraform-locks"
+#}

--- a/infra/modules/bootstrap/bootstrap-variables.tf
+++ b/infra/modules/bootstrap/bootstrap-variables.tf
@@ -1,2 +1,1 @@
-variable "s3_bucket_tf_state_name" {}
 variable "dynamo_db_tf_lock_table_name" {}

--- a/infra/modules/bootstrap/bootstrap.tf
+++ b/infra/modules/bootstrap/bootstrap.tf
@@ -1,33 +1,3 @@
-# Build an S3 bucket to store TF state
-resource "aws_s3_bucket" "state_bucket" {
-  bucket = var.s3_bucket_tf_state_name
-
-  # Prevents Terraform from destroying or replacing this object
-  lifecycle {
-    prevent_destroy = true
-  }
-
-  tags = {
-    Terraform = "true"
-  }
-}
-
-resource "aws_s3_bucket_versioning" "tf_bucket_versioning" {
-  bucket = aws_s3_bucket.state_bucket.id
-  versioning_configuration {
-    status = "Enabled"
-  }
-}
-
-resource "aws_s3_bucket_server_side_encryption_configuration" "tf_bucket_encryption" {
-  bucket = aws_s3_bucket.state_bucket.id
-  rule {
-    apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
-    }
-  }
-}
-
 # Build a DynamoDB to use for terraform state locking
 resource "aws_dynamodb_table" "tf_lock_state" {
   name = var.dynamo_db_tf_lock_table_name

--- a/infra/modules/s3-website/acm.tf
+++ b/infra/modules/s3-website/acm.tf
@@ -1,23 +1,23 @@
-resource "aws_acm_certificate" "ssl_certificate" {
-  provider                  = aws.acm_provider
-  domain_name               = var.domain_name
-  subject_alternative_names = ["*.${var.domain_name}"]
-  validation_method         = "DNS"
-
-  tags = var.common_tags
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-provider "aws" {
-  alias  = "acm_provider"
-  region = "us-east-1"
-}
-
-resource "aws_acm_certificate_validation" "cert_validation" {
-  provider        = aws.acm_provider
-  certificate_arn = aws_acm_certificate.ssl_certificate.arn
-  validation_record_fqdns = [for record in aws_route53_record.s3-website-record : record.fqdn]
-}
+#resource "aws_acm_certificate" "ssl_certificate" {
+#  provider                  = aws.acm_provider
+#  domain_name               = var.domain_name
+#  subject_alternative_names = ["*.${var.domain_name}"]
+#  validation_method         = "DNS"
+#
+#  tags = var.common_tags
+#
+#  lifecycle {
+#    create_before_destroy = true
+#  }
+#}
+#
+#provider "aws" {
+#  alias  = "acm_provider"
+#  region = "us-east-1"
+#}
+#
+#resource "aws_acm_certificate_validation" "cert_validation" {
+#  provider        = aws.acm_provider
+#  certificate_arn = aws_acm_certificate.ssl_certificate.arn
+#  validation_record_fqdns = [for record in aws_route53_record.s3-website-record : record.fqdn]
+#}

--- a/infra/modules/s3-website/acm.tf
+++ b/infra/modules/s3-website/acm.tf
@@ -1,0 +1,23 @@
+resource "aws_acm_certificate" "ssl_certificate" {
+  provider                  = aws.acm_provider
+  domain_name               = var.domain_name
+  subject_alternative_names = ["*.${var.domain_name}"]
+  validation_method         = "DNS"
+
+  tags = var.common_tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+provider "aws" {
+  alias  = "acm_provider"
+  region = "us-east-1"
+}
+
+resource "aws_acm_certificate_validation" "cert_validation" {
+  provider        = aws.acm_provider
+  certificate_arn = aws_acm_certificate.ssl_certificate.arn
+  validation_record_fqdns = [for record in aws_route53_record.s3-website-record : record.fqdn]
+}

--- a/infra/modules/s3-website/cloudfront.tf
+++ b/infra/modules/s3-website/cloudfront.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudfront_distribution" "www_s3_distribution" {
   origin {
-    domain_name = aws_s3_bucket.s3-website.website_endpoint
+    domain_name = aws_s3_bucket.s3-website.bucket_domain_name
     origin_id   = local.s3_origin_id
 
     s3_origin_config {
@@ -8,12 +8,12 @@ resource "aws_cloudfront_distribution" "www_s3_distribution" {
     }
   }
 
+#  aliases = [var.domain_name] #FIXME: certificate is needed, need to request access
+
   enabled             = true
   is_ipv6_enabled     = true
   comment             = "sam2n front-end application"
   default_root_object = "index.html"
-
-  aliases = ["www.${var.domain_name}"]
 
   custom_error_response {
     error_caching_min_ttl = 0
@@ -51,9 +51,6 @@ resource "aws_cloudfront_distribution" "www_s3_distribution" {
   }
 
   viewer_certificate {
-#    acm_certificate_arn      = aws_acm_certificate_validation.cert_validation.certificate_arn
-#    ssl_support_method       = "sni-only"
-#    minimum_protocol_version = "TLSv1.1_2016"
     cloudfront_default_certificate = true
   }
 

--- a/infra/modules/s3-website/cloudfront.tf
+++ b/infra/modules/s3-website/cloudfront.tf
@@ -1,0 +1,64 @@
+resource "aws_cloudfront_distribution" "www_s3_distribution" {
+  origin {
+    domain_name = data.aws_s3_bucket.s3-website.website_endpoint
+    origin_id   = local.s3_origin_id
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.s3-website-origin-identity.cloudfront_access_identity_path
+    }
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "sam2n front-end application"
+  default_root_object = "index.html"
+
+  aliases = ["www.${var.domain_name}"]
+
+  custom_error_response {
+    error_caching_min_ttl = 0
+    error_code            = 404
+    response_code         = 200
+    response_page_path    = "/404.html"
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = var.cache_ttl
+    default_ttl            = var.cache_ttl
+    max_ttl                = var.cache_ttl
+    compress               = true
+  }
+
+  price_class = "PriceClass_100"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.cert_validation.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.1_2016"
+  }
+
+  tags = var.common_tags
+}
+
+resource "aws_cloudfront_origin_access_identity" "s3-website-origin-identity" {
+  comment = "Provides access to sam2n application from edge locations"
+}

--- a/infra/modules/s3-website/cloudfront.tf
+++ b/infra/modules/s3-website/cloudfront.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudfront_distribution" "www_s3_distribution" {
   origin {
-    domain_name = data.aws_s3_bucket.s3-website.website_endpoint
+    domain_name = aws_s3_bucket.s3-website.website_endpoint
     origin_id   = local.s3_origin_id
 
     s3_origin_config {
@@ -51,9 +51,10 @@ resource "aws_cloudfront_distribution" "www_s3_distribution" {
   }
 
   viewer_certificate {
-    acm_certificate_arn      = aws_acm_certificate_validation.cert_validation.certificate_arn
-    ssl_support_method       = "sni-only"
-    minimum_protocol_version = "TLSv1.1_2016"
+#    acm_certificate_arn      = aws_acm_certificate_validation.cert_validation.certificate_arn
+#    ssl_support_method       = "sni-only"
+#    minimum_protocol_version = "TLSv1.1_2016"
+    cloudfront_default_certificate = true
   }
 
   tags = var.common_tags

--- a/infra/modules/s3-website/locals.tf
+++ b/infra/modules/s3-website/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  s3_origin_id = "S3-www.${var.bucket_name}"
+  s3_origin_id = "s3-www.${var.bucket_name}"
 }

--- a/infra/modules/s3-website/locals.tf
+++ b/infra/modules/s3-website/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  s3_origin_id = "S3-www.${var.bucket_name}"
+}

--- a/infra/modules/s3-website/route53.tf
+++ b/infra/modules/s3-website/route53.tf
@@ -1,0 +1,16 @@
+resource "aws_route53_zone" "main" {
+  name = var.domain_name
+  tags = var.common_tags
+}
+
+resource "aws_route53_record" "s3-website-record" {
+  zone_id = aws_route53_zone.main.zone_id
+  name    = "www.${var.domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.www_s3_distribution.domain_name
+    zone_id                = aws_cloudfront_distribution.www_s3_distribution.hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/infra/modules/s3-website/route53.tf
+++ b/infra/modules/s3-website/route53.tf
@@ -1,11 +1,10 @@
-resource "aws_route53_zone" "main" {
+data "aws_route53_zone" "main" {
   name = var.domain_name
-  tags = var.common_tags
 }
 
 resource "aws_route53_record" "s3-website-record" {
-  zone_id = aws_route53_zone.main.zone_id
-  name    = "www.${var.domain_name}"
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = var.domain_name
   type    = "A"
 
   alias {

--- a/infra/modules/s3-website/s3.tf
+++ b/infra/modules/s3-website/s3.tf
@@ -1,0 +1,49 @@
+data "aws_iam_policy_document" "s3_policy" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${data.aws_s3_bucket.s3-website.arn}/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_cloudfront_origin_access_identity.s3-website-origin-identity.iam_arn]
+    }
+  }
+}
+
+data "aws_s3_bucket" "s3-website" {
+  bucket = var.bucket_name
+  tags   = var.common_tags
+}
+
+resource "aws_s3_bucket_policy" "s3-website-policy" {
+  bucket = data.aws_s3_bucket.s3-website.id
+  policy = data.aws_iam_policy_document.s3_policy.json
+}
+
+resource "aws_s3_bucket_acl" "s3-website-acl" {
+  bucket = data.aws_s3_bucket.s3-website.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_cors_configuration" "s3-website-cors" {
+  bucket = data.aws_s3_bucket.s3-website.bucket
+
+  cors_rule {
+    allowed_headers = ["Authorization", "Content-Length"]
+    allowed_methods = ["GET", "POST"]
+    allowed_origins = ["https://${var.domain_name}"]
+    max_age_seconds = 3000
+  }
+}
+
+resource "aws_s3_bucket_website_configuration" "s3-website-configuration" {
+  bucket = data.aws_s3_bucket.s3-website.bucket
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "404.html"
+  }
+}

--- a/infra/modules/s3-website/s3.tf
+++ b/infra/modules/s3-website/s3.tf
@@ -1,7 +1,7 @@
 data "aws_iam_policy_document" "s3_policy" {
   statement {
     actions   = ["s3:GetObject"]
-    resources = ["${data.aws_s3_bucket.s3-website.arn}/*"]
+    resources = ["${aws_s3_bucket.s3-website.arn}/*"]
 
     principals {
       type        = "AWS"
@@ -10,23 +10,23 @@ data "aws_iam_policy_document" "s3_policy" {
   }
 }
 
-data "aws_s3_bucket" "s3-website" {
+resource "aws_s3_bucket" "s3-website" {
   bucket = var.bucket_name
   tags   = var.common_tags
 }
 
 resource "aws_s3_bucket_policy" "s3-website-policy" {
-  bucket = data.aws_s3_bucket.s3-website.id
+  bucket = aws_s3_bucket.s3-website.id
   policy = data.aws_iam_policy_document.s3_policy.json
 }
 
 resource "aws_s3_bucket_acl" "s3-website-acl" {
-  bucket = data.aws_s3_bucket.s3-website.id
+  bucket = aws_s3_bucket.s3-website.id
   acl    = "private"
 }
 
 resource "aws_s3_bucket_cors_configuration" "s3-website-cors" {
-  bucket = data.aws_s3_bucket.s3-website.bucket
+  bucket = aws_s3_bucket.s3-website.bucket
 
   cors_rule {
     allowed_headers = ["Authorization", "Content-Length"]
@@ -37,7 +37,7 @@ resource "aws_s3_bucket_cors_configuration" "s3-website-cors" {
 }
 
 resource "aws_s3_bucket_website_configuration" "s3-website-configuration" {
-  bucket = data.aws_s3_bucket.s3-website.bucket
+  bucket = aws_s3_bucket.s3-website.bucket
 
   index_document {
     suffix = "index.html"

--- a/infra/modules/s3-website/s3.tf
+++ b/infra/modules/s3-website/s3.tf
@@ -20,18 +20,13 @@ resource "aws_s3_bucket_policy" "s3-website-policy" {
   policy = data.aws_iam_policy_document.s3_policy.json
 }
 
-resource "aws_s3_bucket_acl" "s3-website-acl" {
-  bucket = aws_s3_bucket.s3-website.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_cors_configuration" "s3-website-cors" {
   bucket = aws_s3_bucket.s3-website.bucket
 
   cors_rule {
     allowed_headers = ["Authorization", "Content-Length"]
     allowed_methods = ["GET", "POST"]
-    allowed_origins = ["https://${var.domain_name}"]
+    allowed_origins = ["https://${var.domain_name}", "http://${var.domain_name}"]
     max_age_seconds = 3000
   }
 }

--- a/infra/modules/s3-website/variables.tf
+++ b/infra/modules/s3-website/variables.tf
@@ -1,0 +1,23 @@
+variable "domain_name" {
+  type        = string
+  description = "The domain name for the website."
+}
+
+variable "bucket_name" {
+  type        = string
+  description = "The name of the bucket where the website will be hosted"
+}
+
+variable "cache_ttl" {
+  type        = number
+  default     = 31536000
+  description = "Cache TTL for CloudFront distribution"
+}
+
+variable "common_tags" {
+  description = "Common tags applied to all components."
+  default = {
+    Terraform        = true
+    DeveloperManaged = true
+  }
+}

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -1,12 +1,12 @@
 terraform {
   required_version = "~>1.5.0"
-#  backend "s3" {
-#    bucket         = "sam2n-tf-state-bucket"
-#    key            = "terraform-front.tfstate"
-#    region         = "eu-central-1"
-#    dynamodb_table = "sam2n-terraform-locks"
-#    encrypt        = true
-#  }
+  backend "s3" {
+    bucket         = "sam2n-front-app"
+    key            = "terraform-front.tfstate"
+    region         = "eu-central-1"
+    dynamodb_table = "sam2n-terraform-locks"
+    encrypt        = true
+  }
 }
 
 provider "aws" {

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -1,12 +1,12 @@
 terraform {
-  required_version = "~>1.4.0"
-  backend "s3" {
-    bucket         = "sam2n-tf-state-bucket"
-    key            = "terraform-front.tfstate"
-    region         = "eu-central-1"
-    dynamodb_table = "sam2n-terraform-locks"
-    encrypt        = true
-  }
+  required_version = "~>1.5.0"
+#  backend "s3" {
+#    bucket         = "sam2n-tf-state-bucket"
+#    key            = "terraform-front.tfstate"
+#    region         = "eu-central-1"
+#    dynamodb_table = "sam2n-terraform-locks"
+#    encrypt        = true
+#  }
 }
 
 provider "aws" {

--- a/infra/s3-website.tf
+++ b/infra/s3-website.tf
@@ -1,5 +1,5 @@
 module "s3-website" {
   source      = "./modules/s3-website"
   bucket_name = "sam2n-front-app"
-  domain_name = "notjustsport.com"
+  domain_name = "www-notjustsport.net"
 }

--- a/infra/s3-website.tf
+++ b/infra/s3-website.tf
@@ -1,5 +1,5 @@
 module "s3-website" {
   source      = "./modules/s3-website"
-  bucket_name = "sam2n-tf-state-bucket"
-  domain_name = "sam2n-app.com"
+  bucket_name = "sam2n-front-app"
+  domain_name = "notjustsport.com"
 }

--- a/infra/s3-website.tf
+++ b/infra/s3-website.tf
@@ -1,0 +1,5 @@
+module "s3-website" {
+  source      = "./modules/s3-website"
+  bucket_name = "sam2n-tf-state-bucket"
+  domain_name = "sam2n-app.com"
+}


### PR DESCRIPTION
_____________________________________________

What: 

- Added terraform code to create front-end infrastructure: Route53 record, CloudFront distribution and S3 is converted to a website
- tf state still lives in S3
- Upgraded terraform version to 1.5.1
- Added ability to run master workflow on a dispatch